### PR TITLE
Normalize words before submitting them to wiktionary.

### DIFF
--- a/src/scripts/defineSelection.js
+++ b/src/scripts/defineSelection.js
@@ -3,7 +3,7 @@
 var selectionText
 var alternateapi
 var wiktionaryapi
-const normalize = word => word.trim().toUpperCase()===word.trim() ? word.trim() : word.trim().replace(/ /g, '_').toLowerCase()
+const normalize = word => word.trim().toUpperCase()===word.trim() ? word.normalize().trim() : word.normalize().trim().replace(/ /g, '_').toLowerCase()
 
 
 configs.$loaded.then(res => { // Load Wiktionary API

--- a/src/scripts/popup/popupFunctions.js
+++ b/src/scripts/popup/popupFunctions.js
@@ -1,6 +1,6 @@
 'use strict';
 // searchText string modification 
-const normalize = (word) => word.trim().replace(/ /g, '_');		// Convert string to become compatible with the Wiktionary API. Don't conflate this with "humanize".
+const normalize = (word) => word.normalize().trim().replace(/ /g, '_');		// Convert string to become compatible with the Wiktionary API. Don't conflate this with "humanize".
 const humanize = (word) => word.trim().replace(/_/g, ' ');		// This converts a Wiktionary API URL to format better suited for reading.
 // Wiktionary search strings
 const WIKTIONARYURL = (word) => `https://en.wiktionary.org/api/rest_v1/page/definition/${word}`;


### PR DESCRIPTION
Aims to fix #25. I haven't tested it.